### PR TITLE
Use thumbnail_large for Vimeo, always

### DIFF
--- a/components/GetThumbnail.coffee
+++ b/components/GetThumbnail.coffee
@@ -63,12 +63,14 @@ getVimeo = (id, callback) ->
     catch e
       return callback new Error "Failed to parse response"
     return callback new Error 'Missing return info' unless data.length
-    # Start with the largest thumbnail and try to get a better one using
-    # dimensions
     thumbnail = data[0].thumbnail_large
-    if data[0].width and data[0].height
-      urlParts = thumbnail.split '_'
-      thumbnail = "#{urlParts[0]}_#{data[0].width}x#{data[0].height}.jpg"
+    # If webp, use jpg provided url, otherwise use original
+    webpReg = /webp$/
+    match = thumbnail.match webpReg
+    if match
+      url = thumbnail.substring 0, match.index
+      thumbnail = url + 'jpg'
+
     callback null, thumbnail
 
 getEmbedly = (url, callback) ->

--- a/spec/GetThumbnail.coffee
+++ b/spec/GetThumbnail.coffee
@@ -97,13 +97,13 @@ describe 'GetThumbnail component', ->
     it 'should produce thumbnail URL for Vimeo', (done) ->
       @timeout 6000
       out.on 'data', (data) ->
-        chai.expect(data).to.equal 'http://i.vimeocdn.com/video/470731940_1280x720.jpg'
+        chai.expect(data).to.equal 'http://i.vimeocdn.com/video/470731940_640.jpg'
         done()
       ins.send '//player.vimeo.com/video/91393694?title=0&amp;byline=0&amp;color=ffffff'
     it 'should produce thumbnail URL for Vimeo via Embed.ly', (done) ->
       @timeout 6000
       out.on 'data', (data) ->
-        chai.expect(data).to.equal 'http://i.vimeocdn.com/video/475921185_1280x720.jpg'
+        chai.expect(data).to.equal 'http://i.vimeocdn.com/video/475921185_640.jpg'
         done()
       ins.send '//cdn.embedly.com/widgets/media.html?src=http%3A%2F%2Fplayer.vimeo.com%2Fvideo%2F95895989&src_secure=1&url=http%3A%2F%2Fvimeo.com%2F95895989&image=http%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F475921185_1280.jpg&key=internal&type=text%2Fhtml&schema=vimeo'
     it 'should produce thumbnail URL for SoundCloud via Embed.ly', (done) ->
@@ -316,7 +316,7 @@ describe 'GetThumbnail component', ->
       @timeout 6000
       out.on 'data', (data) ->
         chai.expect(data).to.be.an 'object'
-        chai.expect(data.src).to.equal 'https://i.vimeocdn.com/video/470731940_1280x720.jpg'
+        chai.expect(data.src).to.equal 'https://i.vimeocdn.com/video/470731940_640.jpg'
         done()
       ins.send
         video: '//player.vimeo.com/video/91393694?title=0&amp;byline=0&amp;color=ffffff'
@@ -339,7 +339,7 @@ describe 'GetThumbnail component', ->
       @timeout 6000
       out.on 'data', (data) ->
         chai.expect(data).to.be.an 'object'
-        chai.expect(data.src).to.be.equal 'https://i.vimeocdn.com/video/605511151_1920x1080.jpg'
+        chai.expect(data.src).to.be.equal 'https://i.vimeocdn.com/video/605511151_640.jpg'
         done()
       ins.send
         video: 'https://vimeo.com/169598313'


### PR DESCRIPTION
We were doing that already, always getting the thumbnail_large and using it to get a bigger image. The problem is that Vimeo accepts any value for the bigger image wich causes upscaling. We're going with the original thumbnail_large instead and targeting jpg instead of webp